### PR TITLE
Adding basic testing for string conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -26,8 +26,9 @@
   },
   "homepage": "https://github.com/IonicaBizau/camelo#readme",
   "dependencies": {
-    "regex-escape": "^3.3.0",
-    "uc-first-array": "^1.0.0"
+    "mocha": "^8.2.0",
+    "regex-escape": "^3.4.10",
+    "uc-first-array": "^1.1.10"
   },
   "files": [
     "bin/",

--- a/test/validateStrings.js
+++ b/test/validateStrings.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+const camelo = require("../lib");
+
+describe('Camelo', function() {
+  describe('test 01', function() {
+    it('should return a camel version of the string considering spaces and _', function() {
+        var result = camelo("default behavior_using*strange|chars");
+      assert.strictEqual("defaultBehaviorUsingStrangeChars", result);
+    });
+
+    it('should return a camel version of the string considering _ but not spaces', function() {
+        var result = camelo("handling_underscores but not spaces", "_");
+      assert.strictEqual("handlingUnderscores but not spaces", result);
+    });
+
+    it('should return a camel version of the string considering _ and spaces uppercasing the first character', function() {
+        var result = camelo("uppercase first char as well", " ", true);
+      assert.strictEqual("UppercaseFirstCharAsWell", result);
+    });
+
+    it('should return a camel version of the string considering _, spaces and skipping * and :', function() {
+        var result = camelo("handling*asterisk:and:colons", ["*", ":"]);
+      assert.strictEqual("handlingAsteriskAndColons", result);
+    });
+  });
+});


### PR DESCRIPTION
Hi

Fix https://github.com/IonicaBizau/camelo/issues/15 

You can just run npm test and the tests will run. Feel free to rename the titles of the test for something that makes more sense. 