### PR TITLE
Upgrade Mocha to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/IonicaBizau/camelo#readme",
   "devDependencies": {
-    "mocha": "^8.2.0"
+    "mocha": "^9.2.0"
   },
   "dependencies": {
     "regex-escape": "^3.4.10",


### PR DESCRIPTION
[GitHub Advisory](https://github.com/advisories/GHSA-93q8-gq69-wqmw)

Present in mocha@8.2.0:
https://github.com/mochajs/mocha/blob/afe8daac603d398743dd5572f497ba088193bf53/package-lock.json#L2518-L2522
![image](https://user-images.githubusercontent.com/99439005/154742659-95bb4699-8836-448b-a621-b9a02f1ab39c.png)